### PR TITLE
Fix integrate argument naming for DataArray

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -3481,18 +3481,25 @@ class DataArray(AbstractArray, DataWithCoords):
         return self._from_temp_dataset(ds)
 
     def integrate(
-        self, dim: Union[Hashable, Sequence[Hashable]], datetime_unit: str = None
+        self,
+        coord: Union[Hashable, Sequence[Hashable]],
+        datetime_unit: str = None,
+        *,
+        dim: Union[Hashable, Sequence[Hashable]] = None,
     ) -> "DataArray":
         """ integrate the array with the trapezoidal rule.
 
         .. note::
-            This feature is limited to simple cartesian geometry, i.e. dim
+            This feature is limited to simple cartesian geometry, i.e. coord
             must be one dimensional.
 
         Parameters
         ----------
-        dim : hashable, or sequence of hashable
+        coord : hashable, or sequence of hashable
             Coordinate(s) used for the integration.
+        dim : hashable, or sequence of hashable, optional
+            Deprecated name for ``coord``. Cannot be used together with
+            ``coord``.
         datetime_unit : {"Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns", \
                          "ps", "fs", "as"}, optional
             Can be used to specify the unit if datetime coordinate is used.
@@ -3528,7 +3535,17 @@ class DataArray(AbstractArray, DataWithCoords):
         array([5.4, 6.6, 7.8])
         Dimensions without coordinates: y
         """
-        ds = self._to_temp_dataset().integrate(dim, datetime_unit)
+        if dim is not None:
+            warnings.warn(
+                "`dim` has been renamed to `coord` and will be removed in a future release",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if coord is not None:
+                raise TypeError("cannot specify both `coord` and `dim`")
+            coord = dim
+
+        ds = self._to_temp_dataset().integrate(coord, datetime_unit)
         return self._from_temp_dataset(ds)
 
     def unify_chunks(self) -> "DataArray":

--- a/xarray/tests/test_dataset.py
+++ b/xarray/tests/test_dataset.py
@@ -6656,6 +6656,18 @@ def test_trapz_datetime(dask, which_datetime):
     assert_allclose(actual, actual2 / 24.0)
 
 
+def test_integrate_dim_kwarg_deprecated():
+    da = xr.DataArray(
+        np.arange(5), dims="x", coords={"x": np.linspace(0.0, 1.0, 5)}
+    )
+
+    with pytest.warns(FutureWarning):
+        result = da.integrate(dim="x")
+
+    expected = da.integrate("x")
+    assert_equal(result, expected)
+
+
 def test_no_dict():
     d = Dataset()
     with pytest.raises(AttributeError):


### PR DESCRIPTION
## Summary
- switch DataArray.integrate from `dim` to `coord`
- warn when using deprecated `dim` kwarg
- test deprecated kwarg handling

## Testing
- `pre-commit run --files xarray/core/dataarray.py xarray/tests/test_dataset.py doc/computation.rst` *(fails: `Username for 'https://gitlab.com'`)*
- `pytest -k integrate -q` *(fails: `ModuleNotFoundError: No module named 'pkg_resources'`)*

------
https://chatgpt.com/codex/tasks/task_e_68516abb0390832a9ec00c4d08a33690